### PR TITLE
Add docker image tag overriding feature

### DIFF
--- a/gen_tag_override.py
+++ b/gen_tag_override.py
@@ -1,8 +1,24 @@
 #!/usr/bin/env python
-""" Manually generate a tag override hash """
-import base64
-import hashlib
-import sys
+#
+# ShinyProxy
+#
+# Copyright (C) 2016-2017 Open Analytics
+#
+# ===========================================================================
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# The Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with this program.  If not, see <http://www.apache.org/licenses/>
+#
 
 assert sys.version_info >= (3, 2)
 

--- a/gen_tag_override.py
+++ b/gen_tag_override.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+""" Manually generate a tag override hash """
+import base64
+import hashlib
+import sys
+
+assert sys.version_info >= (3, 2)
+
+if len(sys.argv) < 4:
+    print("Usage: ./gen_tag_override.py <secret file> <app name> <tag name> [expiry unix time]")
+    print("Note: Unix time is seconds since Jan 1, 1970 UTC")
+    print("To get unix time, you can use https://www.unixtimestamp.com/")
+    exit()
+
+with open(sys.argv[1], "rb") as f:
+    SECRET = f.read()
+APP_NAME = sys.argv[2]
+TAG_NAME = sys.argv[3]
+if len(sys.argv) >= 5:
+    EXPIRY_TIMESTAMP = int(sys.argv[4]) * 1000
+else:
+    EXPIRY_TIMESTAMP = 0
+
+
+HASHER = hashlib.sha256()
+HASHER.update(APP_NAME.encode())
+HASHER.update(b"\0")
+HASHER.update(TAG_NAME.encode())
+HASHER.update(b"\0")
+HASHER.update(EXPIRY_TIMESTAMP.to_bytes(8, byteorder='big'))
+HASHER.update(b"\0")
+HASHER.update(SECRET)
+
+print(base64.urlsafe_b64encode(HASHER.digest()).decode())

--- a/src/main/java/eu/openanalytics/WebSecurityConfig.java
+++ b/src/main/java/eu/openanalytics/WebSecurityConfig.java
@@ -82,7 +82,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 			for (ShinyApp app: appService.getApps()) {
 				if (app.getGroups() == null || app.getGroups().length == 0) continue;
 				String[] appGroups = Arrays.stream(app.getGroups()).map(s -> s.toUpperCase()).toArray(i -> new String[i]);
-				http.authorizeRequests().antMatchers("/app/" + app.getName()).hasAnyRole(appGroups);
+				http.authorizeRequests().antMatchers("/app/" + app.getName(), "/appOverride/*/" + app.getName()).hasAnyRole(appGroups);
 			}
 
 			// Limit access to the admin pages

--- a/src/main/java/eu/openanalytics/controllers/AppController.java
+++ b/src/main/java/eu/openanalytics/controllers/AppController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import eu.openanalytics.ShinyProxyApplication;
 import eu.openanalytics.services.AppService;
 import eu.openanalytics.services.DockerService;
+import eu.openanalytics.services.DockerService.AppInstanceDetails;
 
 @Controller
 public class AppController extends BaseController {
@@ -46,7 +47,8 @@ public class AppController extends BaseController {
 	String app(ModelMap map, HttpServletRequest request) {
 		prepareMap(map, request);
 		
-		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), false);
+		AppInstanceDetails details = new AppInstanceDetails(getUserName(request), getAppName(request));
+		String mapping = dockerService.getMapping(details, false);
 		String contextPath = ShinyProxyApplication.getContextPath(environment);
 
 		map.put("appTitle", getAppTitle(request));
@@ -60,7 +62,8 @@ public class AppController extends BaseController {
 	@RequestMapping(value="/app/*", method=RequestMethod.POST)
 	@ResponseBody
 	String startApp(HttpServletRequest request) {
-		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), true);
+		AppInstanceDetails details = new AppInstanceDetails(getUserName(request), getAppName(request));
+		String mapping = dockerService.getMapping(details, true);
 		return appService.buildContainerPath(mapping, request);
 	}
 }

--- a/src/main/java/eu/openanalytics/controllers/AppController.java
+++ b/src/main/java/eu/openanalytics/controllers/AppController.java
@@ -50,7 +50,7 @@ public class AppController extends BaseController {
 		String contextPath = ShinyProxyApplication.getContextPath(environment);
 
 		map.put("appTitle", getAppTitle(request));
-		map.put("container", buildContainerPath(mapping, request));
+		map.put("container", appService.buildContainerPath(mapping, request));
 		map.put("heartbeatRate", environment.getProperty("shiny.proxy.heartbeat-rate", "10000"));
 		map.put("heartbeatPath", contextPath + "/heartbeat");
 		
@@ -61,17 +61,6 @@ public class AppController extends BaseController {
 	@ResponseBody
 	String startApp(HttpServletRequest request) {
 		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), true);
-		return buildContainerPath(mapping, request);
-	}
-	
-	private String buildContainerPath(String mapping, HttpServletRequest request) {
-		if (mapping == null) return "";
-		
-		String queryString = request.getQueryString();
-		queryString = (queryString == null) ? "" : "?" + queryString;
-		
-		String contextPath = ShinyProxyApplication.getContextPath(environment);
-		String containerPath = contextPath + "/" + mapping + environment.getProperty("shiny.proxy.landing-page") + queryString;
-		return containerPath;
+		return appService.buildContainerPath(mapping, request);
 	}
 }

--- a/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
+++ b/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
@@ -219,7 +219,7 @@ public class AppOverrideController extends BaseController {
 			}
 		}
 		byte[] hashBytes = hashOverride(secret, getAppName(request), getTagOverride(request), expiresAt);
-		byte[] shortHashBytes = Arrays.copyOfRange(hashBytes, 0, tagOverrideService.getURLSigLen());
+		byte[] shortHashBytes = Arrays.copyOfRange(hashBytes, 0, tagOverrideService.getDefaultSigLen());
 		// No longer an actual signature, just a hash including a secret
 		String signature = Base64Utils.encodeToUrlSafeString(shortHashBytes);
 		String overrideLocation = "?expires=" + expiresAt + "&sig=" + signature;

--- a/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
+++ b/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
@@ -23,6 +23,7 @@ package eu.openanalytics.controllers;
 import eu.openanalytics.ShinyProxyApplication;
 import eu.openanalytics.services.AppService;
 import eu.openanalytics.services.DockerService;
+import eu.openanalytics.services.DockerService.AppInstanceDetails;
 import eu.openanalytics.services.TagOverrideService;
 
 import java.io.UnsupportedEncodingException;
@@ -89,7 +90,8 @@ public class AppOverrideController extends BaseController {
 		if (!validateOverride(request, response)) return null;
 		prepareMap(map, request);
 		
-		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), getTagOverride(request), false);
+		AppInstanceDetails details = new AppInstanceDetails(getUserName(request), getAppName(request), getTagOverride(request));
+		String mapping = dockerService.getMapping(details, false);
 		String contextPath = ShinyProxyApplication.getContextPath(environment);
 
 		map.put("appTitle", getAppTitle(request));
@@ -104,7 +106,8 @@ public class AppOverrideController extends BaseController {
 	@ResponseBody
 	String startAppOverride(HttpServletRequest request, HttpServletResponse response) throws InvalidKeyException, NoSuchAlgorithmException, SignatureException {
 		if (!validateOverride(request, response)) return null;
-		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), getTagOverride(request), true);
+		AppInstanceDetails details = new AppInstanceDetails(getUserName(request), getAppName(request), getTagOverride(request));
+		String mapping = dockerService.getMapping(details, true);
 		return appService.buildContainerPath(mapping, request);
 	}
 

--- a/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
+++ b/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
@@ -58,32 +58,32 @@ public class AppOverrideController extends BaseController {
 	DockerService dockerService;
 
 	@Inject
-    AppService appService;
+	AppService appService;
 
 	@Inject
-    TagOverrideService tagOverrideService;
+	TagOverrideService tagOverrideService;
 
-    private void updateSignatureWithOverride(Signature signature, String app, String tag, long expires) throws SignatureException {
-        byte[] appBytes;
-        byte[] tagBytes;
-        try {
-            appBytes = app.getBytes("UTF8");
-            tagBytes = tag.getBytes("UTF8");
+	private void updateSignatureWithOverride(Signature signature, String app, String tag, long expires) throws SignatureException {
+		byte[] appBytes;
+		byte[] tagBytes;
+		try {
+			appBytes = app.getBytes("UTF8");
+			tagBytes = tag.getBytes("UTF8");
 		} catch (UnsupportedEncodingException e) {
-            appBytes = app.getBytes();
-            tagBytes = tag.getBytes();
+			appBytes = app.getBytes();
+			tagBytes = tag.getBytes();
 		}
-        byte[] expiresBytes = Longs.toByteArray(expires);
-        signature.update(appBytes);
-        signature.update((byte) 0);
-        signature.update(tagBytes);
-        signature.update((byte) 0);
-        signature.update(expiresBytes);
-    }
+		byte[] expiresBytes = Longs.toByteArray(expires);
+		signature.update(appBytes);
+		signature.update((byte) 0);
+		signature.update(tagBytes);
+		signature.update((byte) 0);
+		signature.update(expiresBytes);
+	}
 
 	@RequestMapping(value="/appOverride/**", params={"sig", "expires"}, method=RequestMethod.GET)
 	String appOverride(ModelMap map, Principal principal, HttpServletRequest request, HttpServletResponse response) throws InvalidKeyException, NoSuchAlgorithmException, SignatureException {
-        if (!validateOverride(request, response)) return null;
+		if (!validateOverride(request, response)) return null;
 		prepareMap(map, request);
 		
 		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), getTagOverride(request), false);
@@ -94,122 +94,122 @@ public class AppOverrideController extends BaseController {
 		map.put("heartbeatRate", environment.getProperty("shiny.proxy.heartbeat-rate", "10000"));
 		map.put("heartbeatPath", contextPath + "/heartbeat");
 		
-        return "app";
-    }
+		return "app";
+	}
 
 	@RequestMapping(value="/appOverride/**", params={"sig", "expires"}, method=RequestMethod.POST)
 	@ResponseBody
 	String startAppOverride(HttpServletRequest request, HttpServletResponse response) throws InvalidKeyException, NoSuchAlgorithmException, SignatureException {
-        if (!validateOverride(request, response)) return null;
-        String mapping = dockerService.getMapping(getUserName(request), getAppName(request), getTagOverride(request), true);
-        return appService.buildContainerPath(mapping, request);
-    }
+		if (!validateOverride(request, response)) return null;
+		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), getTagOverride(request), true);
+		return appService.buildContainerPath(mapping, request);
+	}
 
 	private boolean validateOverride(HttpServletRequest request, HttpServletResponse response) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
-        String appName = getAppName(request);
-        String tagOverride = getTagOverride(request);
-        if (appName == null || tagOverride == null) {
-            sendSimpleResponse(response, 400, "Bad Request: tag override or app name not specified");
-            return false;
-        }
-        byte[] signature;
-        try {
-            signature = Base64Utils.decodeFromUrlSafeString(request.getParameter("sig"));
-        } catch (Exception e) {
-            sendSimpleResponse(response, 400, "Bad Request: failed to decode signature as hex");
-            return false;
-        }
-        long expires;
-        try {
-            expires = Long.parseLong(request.getParameter("expires"));
-        } catch (NumberFormatException e) {
-            sendSimpleResponse(response, 400, "Bad Request: expires parameter not a valid long");
-            return false;
-        }
-        if (expires > 0 && expires < new Date().getTime()) {
-            sendSimpleResponse(response, 400, "Bad Request: tag override has expired");
-            return false;
-        }
-        KeyPair keyPair = tagOverrideService.getKeyPair();
-        if (keyPair == null) {
-            sendSimpleResponse(response, 501, "Not Implemented: tag overriding is either disabled or failed to intialize");
-            return false;
-        }
-        Signature rsa = Signature.getInstance("SHA256withRSA");
-        rsa.initVerify(keyPair.getPublic());
-        updateSignatureWithOverride(rsa, appName, tagOverride, expires);
-        if (!rsa.verify(signature)) {
-            sendSimpleResponse(response, 400, "Bad Request: signature verification failed");
-            return false;
-        }
+		String appName = getAppName(request);
+		String tagOverride = getTagOverride(request);
+		if (appName == null || tagOverride == null) {
+			sendSimpleResponse(response, 400, "Bad Request: tag override or app name not specified");
+			return false;
+		}
+		byte[] signature;
+		try {
+			signature = Base64Utils.decodeFromUrlSafeString(request.getParameter("sig"));
+		} catch (Exception e) {
+			sendSimpleResponse(response, 400, "Bad Request: failed to decode signature as hex");
+			return false;
+		}
+		long expires;
+		try {
+			expires = Long.parseLong(request.getParameter("expires"));
+		} catch (NumberFormatException e) {
+			sendSimpleResponse(response, 400, "Bad Request: expires parameter not a valid long");
+			return false;
+		}
+		if (expires > 0 && expires < new Date().getTime()) {
+			sendSimpleResponse(response, 400, "Bad Request: tag override has expired");
+			return false;
+		}
+		KeyPair keyPair = tagOverrideService.getKeyPair();
+		if (keyPair == null) {
+			sendSimpleResponse(response, 501, "Not Implemented: tag overriding is either disabled or failed to intialize");
+			return false;
+		}
+		Signature rsa = Signature.getInstance("SHA256withRSA");
+		rsa.initVerify(keyPair.getPublic());
+		updateSignatureWithOverride(rsa, appName, tagOverride, expires);
+		if (!rsa.verify(signature)) {
+			sendSimpleResponse(response, 400, "Bad Request: signature verification failed");
+			return false;
+		}
 		return true;
 	}
 
-    @RequestMapping(value="/appOverride/**", method={RequestMethod.GET, RequestMethod.POST})
-    @ResponseBody
-    String createAppOverride(
-        HttpServletRequest request, HttpServletResponse response,
-        // number of milliseconds before signature expires
-        // clamped by config
-        @RequestParam(value="expiry", required=false) Long expiry
-    ) throws SignatureException, NoSuchAlgorithmException, InvalidKeyException {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            // User is not logged in
-            response.setStatus(401);
-            response.setContentType("text/plain");
-            return "Unauthorized: you must sign in to create app overrides";
-        }
-        if (!userService.isAdmin(authentication)) {
-            // User is logged in, but is not an admin
-            response.setStatus(403);
-            response.setContentType("text/plain");
-            return "Forbidden: only admins may create app overrides";
-        }
-        KeyPair keyPair = tagOverrideService.getKeyPair();
-        if (keyPair == null) {
-            response.setStatus(501);
-            response.setContentType("text/plain");
-            return "Not Implemented: tag overriding is either disabled or failed to intialize";
-        }
-        long configExpiry = ((long) tagOverrideService.getTagOverrideExpirationDays()) * 1000 * 60 * 60 * 24;
-        if (expiry == null) {
-            expiry = configExpiry;
-        } else if (configExpiry > 0) {
-            expiry = Math.min(expiry, configExpiry);
-        }
-        long expiresAt;
-        if (expiry == 0) {
-            expiresAt = 0;
-        } else {
-            expiresAt = new Date().getTime() + expiry;
-        }
-        Signature rsa = Signature.getInstance("SHA256withRSA");
-        rsa.initSign(keyPair.getPrivate());
-        updateSignatureWithOverride(rsa, getAppName(request), getTagOverride(request), expiresAt);
-        byte[] signatureBytes = rsa.sign();
-        String signature = Base64Utils.encodeToUrlSafeString(signatureBytes);
-        String overrideLocation = "?expires=" + expiresAt + "&sig=" + signature;
-        String requestQS = request.getQueryString();
-        if (requestQS != null) {
-            requestQS = "&" + requestQS;
-            int expiryIdx = requestQS.indexOf("&expiry=");
-            int nextParamIdx = requestQS.indexOf('&', expiryIdx + 1);
-            if (expiryIdx != -1) {
-                String otherQS = requestQS.substring(0, expiryIdx);
-                if (nextParamIdx != -1) {
-                    otherQS += requestQS.substring(nextParamIdx);
-                }
-                requestQS = otherQS;
-            }
-            overrideLocation += requestQS;
-        }
-        if (request.getMethod() == "GET") {
-            response.setStatus(302);
-            response.setHeader("Location", overrideLocation);
-            return null;
-        } else {
-            return request.getRequestURI() + overrideLocation;
-        }
-    }
+	@RequestMapping(value="/appOverride/**", method={RequestMethod.GET, RequestMethod.POST})
+	@ResponseBody
+	String createAppOverride(
+		HttpServletRequest request, HttpServletResponse response,
+		// number of milliseconds before signature expires
+		// clamped by config
+		@RequestParam(value="expiry", required=false) Long expiry
+	) throws SignatureException, NoSuchAlgorithmException, InvalidKeyException {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || !authentication.isAuthenticated()) {
+			// User is not logged in
+			response.setStatus(401);
+			response.setContentType("text/plain");
+			return "Unauthorized: you must sign in to create app overrides";
+		}
+		if (!userService.isAdmin(authentication)) {
+			// User is logged in, but is not an admin
+			response.setStatus(403);
+			response.setContentType("text/plain");
+			return "Forbidden: only admins may create app overrides";
+		}
+		KeyPair keyPair = tagOverrideService.getKeyPair();
+		if (keyPair == null) {
+			response.setStatus(501);
+			response.setContentType("text/plain");
+			return "Not Implemented: tag overriding is either disabled or failed to intialize";
+		}
+		long configExpiry = ((long) tagOverrideService.getTagOverrideExpirationDays()) * 1000 * 60 * 60 * 24;
+		if (expiry == null) {
+			expiry = configExpiry;
+		} else if (configExpiry > 0) {
+			expiry = Math.min(expiry, configExpiry);
+		}
+		long expiresAt;
+		if (expiry == 0) {
+			expiresAt = 0;
+		} else {
+			expiresAt = new Date().getTime() + expiry;
+		}
+		Signature rsa = Signature.getInstance("SHA256withRSA");
+		rsa.initSign(keyPair.getPrivate());
+		updateSignatureWithOverride(rsa, getAppName(request), getTagOverride(request), expiresAt);
+		byte[] signatureBytes = rsa.sign();
+		String signature = Base64Utils.encodeToUrlSafeString(signatureBytes);
+		String overrideLocation = "?expires=" + expiresAt + "&sig=" + signature;
+		String requestQS = request.getQueryString();
+		if (requestQS != null) {
+			requestQS = "&" + requestQS;
+			int expiryIdx = requestQS.indexOf("&expiry=");
+			int nextParamIdx = requestQS.indexOf('&', expiryIdx + 1);
+			if (expiryIdx != -1) {
+				String otherQS = requestQS.substring(0, expiryIdx);
+				if (nextParamIdx != -1) {
+					otherQS += requestQS.substring(nextParamIdx);
+				}
+				requestQS = otherQS;
+			}
+			overrideLocation += requestQS;
+		}
+		if (request.getMethod() == "GET") {
+			response.setStatus(302);
+			response.setHeader("Location", overrideLocation);
+			return null;
+		} else {
+			return request.getRequestURI() + overrideLocation;
+		}
+	}
 }

--- a/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
+++ b/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
@@ -1,0 +1,110 @@
+/**
+ * ShinyProxy
+ *
+ * Copyright (C) 2016-2017 Open Analytics
+ *
+ * ===========================================================================
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License as published by
+ * The Apache Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License
+ * along with this program.  If not, see <http://www.apache.org/licenses/>
+ */
+package eu.openanalytics.controllers;
+
+import eu.openanalytics.ShinyProxyApplication;
+import eu.openanalytics.services.AppService;
+import eu.openanalytics.services.DockerService;
+import java.security.Principal;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.log4j.Logger;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class AppOverrideController extends BaseController {
+
+    private Logger log = Logger.getLogger(AppOverrideController.class);
+
+	@Inject
+	DockerService dockerService;
+	
+	@Inject
+	AppService appService;
+
+	@RequestMapping(value="/appOverride/**", params={"sig", "expires"}, method=RequestMethod.GET)
+	String appOverride(ModelMap map, Principal principal, HttpServletRequest request) {
+        // TODO: check sig and expires
+		prepareMap(map, request);
+		
+		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), getTagOverride(request), false);
+		String contextPath = ShinyProxyApplication.getContextPath(environment);
+
+		map.put("appTitle", getAppTitle(request));
+		map.put("container", appService.buildContainerPath(mapping, request));
+		map.put("heartbeatRate", environment.getProperty("shiny.proxy.heartbeat-rate", "10000"));
+		map.put("heartbeatPath", contextPath + "/heartbeat");
+		
+        return "app";
+    }
+
+	@RequestMapping(value="/appOverride/**", params={"sig", "expires"}, method=RequestMethod.POST)
+	@ResponseBody
+	String startAppOverride(HttpServletRequest request) {
+        // TODO: check sig and expires
+		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), getTagOverride(request), true);
+		return appService.buildContainerPath(mapping, request);
+    }
+
+    @RequestMapping(value="/appOverride/**", method={RequestMethod.GET, RequestMethod.POST})
+    @ResponseBody
+    String createAppOverride(
+        HttpServletRequest request, HttpServletResponse response,
+        // number of seconds before signature expires
+        // clamped by config
+        @RequestParam("expiry") Integer expiry
+    ) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            // User is not logged in
+            response.setStatus(401);
+            response.setContentType("text/plain");
+            return "Unauthorized: you must sign in to create app overrides";
+        }
+        if (!userService.isAdmin(authentication)) {
+            // User is logged in, but is not an admin
+            response.setStatus(403);
+            response.setContentType("text/plain");
+            return "Forbidden: only admins may create app overrides";
+        }
+        // User is logged in and is an admin
+        String overrideLocation = "?sig=TODO&expires=TODO";
+        String requestQS = request.getQueryString();
+        if (requestQS != null) {
+            overrideLocation += "&" + requestQS;
+        }
+        if (request.getMethod() == "GET") {
+            response.setStatus(302);
+            response.setHeader("Location", overrideLocation);
+            return null;
+        } else {
+            return overrideLocation;
+        }
+    }
+}

--- a/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
+++ b/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
@@ -176,10 +176,14 @@ public class AppOverrideController extends BaseController {
 		if (expiry == null) {
 			expiry = configExpiry;
 		} else if (configExpiry > 0) {
-			expiry = Math.min(expiry, configExpiry);
+			if (expiry > 0) {
+				expiry = Math.min(expiry, configExpiry);
+			} else {
+				expiry = configExpiry;
+			}
 		}
 		long expiresAt;
-		if (expiry == 0) {
+		if (expiry <= 0) {
 			expiresAt = 0;
 		} else {
 			expiresAt = new Date().getTime() + expiry;

--- a/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
+++ b/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
@@ -23,10 +23,23 @@ package eu.openanalytics.controllers;
 import eu.openanalytics.ShinyProxyApplication;
 import eu.openanalytics.services.AppService;
 import eu.openanalytics.services.DockerService;
+import eu.openanalytics.services.TagOverrideService;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.util.Date;
+
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.log4j.Logger;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -37,20 +50,41 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.google.common.primitives.Longs;
+
 @Controller
 public class AppOverrideController extends BaseController {
 
-    private Logger log = Logger.getLogger(AppOverrideController.class);
-
 	@Inject
 	DockerService dockerService;
-	
+
 	@Inject
-	AppService appService;
+    AppService appService;
+
+	@Inject
+    TagOverrideService tagOverrideService;
+
+    private void updateSignatureWithOverride(Signature signature, String app, String tag, long expires) throws SignatureException {
+        byte[] appBytes;
+        byte[] tagBytes;
+        try {
+            appBytes = app.getBytes("UTF8");
+            tagBytes = tag.getBytes("UTF8");
+		} catch (UnsupportedEncodingException e) {
+            appBytes = app.getBytes();
+            tagBytes = tag.getBytes();
+		}
+        byte[] expiresBytes = Longs.toByteArray(expires);
+        signature.update(appBytes);
+        signature.update((byte) 0);
+        signature.update(tagBytes);
+        signature.update((byte) 0);
+        signature.update(expiresBytes);
+    }
 
 	@RequestMapping(value="/appOverride/**", params={"sig", "expires"}, method=RequestMethod.GET)
-	String appOverride(ModelMap map, Principal principal, HttpServletRequest request) {
-        // TODO: check sig and expires
+	String appOverride(ModelMap map, Principal principal, HttpServletRequest request, HttpServletResponse response) throws InvalidKeyException, NoSuchAlgorithmException, SignatureException {
+        if (!validateOverride(request, response)) return null;
 		prepareMap(map, request);
 		
 		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), getTagOverride(request), false);
@@ -66,20 +100,60 @@ public class AppOverrideController extends BaseController {
 
 	@RequestMapping(value="/appOverride/**", params={"sig", "expires"}, method=RequestMethod.POST)
 	@ResponseBody
-	String startAppOverride(HttpServletRequest request) {
-        // TODO: check sig and expires
-		String mapping = dockerService.getMapping(getUserName(request), getAppName(request), getTagOverride(request), true);
-		return appService.buildContainerPath(mapping, request);
+	String startAppOverride(HttpServletRequest request, HttpServletResponse response) throws InvalidKeyException, NoSuchAlgorithmException, SignatureException {
+        if (!validateOverride(request, response)) return null;
+        String mapping = dockerService.getMapping(getUserName(request), getAppName(request), getTagOverride(request), true);
+        return appService.buildContainerPath(mapping, request);
     }
+
+	private boolean validateOverride(HttpServletRequest request, HttpServletResponse response) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        String appName = getAppName(request);
+        String tagOverride = getTagOverride(request);
+        if (appName == null || tagOverride == null) {
+            sendSimpleResponse(response, 400, "Bad Request: tag override or app name not specified");
+            return false;
+        }
+        byte[] signature;
+        try {
+            signature = Hex.decodeHex(request.getParameter("sig").toCharArray());
+        } catch (DecoderException e) {
+            sendSimpleResponse(response, 400, "Bad Request: failed to decode signature as hex");
+            return false;
+        }
+        long expires;
+        try {
+            expires = Long.parseLong(request.getParameter("expires"));
+        } catch (NumberFormatException e) {
+            sendSimpleResponse(response, 400, "Bad Request: expires parameter not a valid long");
+            return false;
+        }
+        if (expires > 0 && expires < new Date().getTime()) {
+            sendSimpleResponse(response, 400, "Bad Request: tag override has expired");
+            return false;
+        }
+        KeyPair keyPair = tagOverrideService.getKeyPair();
+        if (keyPair == null) {
+            sendSimpleResponse(response, 501, "Not Implemented: tag overriding is either disabled or failed to intialize");
+            return false;
+        }
+        Signature dsa = Signature.getInstance("SHA256withDSA");
+        dsa.initVerify(keyPair.getPublic());
+        updateSignatureWithOverride(dsa, appName, tagOverride, expires);
+        if (!dsa.verify(signature)) {
+            sendSimpleResponse(response, 400, "Bad Request: signature verification failed");
+            return false;
+        }
+		return true;
+	}
 
     @RequestMapping(value="/appOverride/**", method={RequestMethod.GET, RequestMethod.POST})
     @ResponseBody
     String createAppOverride(
         HttpServletRequest request, HttpServletResponse response,
-        // number of seconds before signature expires
+        // number of milliseconds before signature expires
         // clamped by config
-        @RequestParam("expiry") Integer expiry
-    ) {
+        @RequestParam(value="expiry", required=false) Long expiry
+    ) throws SignatureException, NoSuchAlgorithmException, InvalidKeyException {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
             // User is not logged in
@@ -93,18 +167,50 @@ public class AppOverrideController extends BaseController {
             response.setContentType("text/plain");
             return "Forbidden: only admins may create app overrides";
         }
-        // User is logged in and is an admin
-        String overrideLocation = "?sig=TODO&expires=TODO";
+        KeyPair keyPair = tagOverrideService.getKeyPair();
+        if (keyPair == null) {
+            response.setStatus(501);
+            response.setContentType("text/plain");
+            return "Not Implemented: tag overriding is either disabled or failed to intialize";
+        }
+        long configExpiry = ((long) tagOverrideService.getTagOverrideExpirationDays()) * 1000 * 60 * 60 * 24;
+        if (expiry == null) {
+            expiry = configExpiry;
+        } else if (configExpiry > 0) {
+            expiry = Math.min(expiry, configExpiry);
+        }
+        long expiresAt;
+        if (expiry == 0) {
+            expiresAt = 0;
+        } else {
+            expiresAt = new Date().getTime() + expiry;
+        }
+        Signature dsa = Signature.getInstance("SHA256withDSA");
+        dsa.initSign(keyPair.getPrivate());
+        updateSignatureWithOverride(dsa, getAppName(request), getTagOverride(request), expiresAt);
+        byte[] signatureBytes = dsa.sign();
+        String signature = Hex.encodeHexString(signatureBytes);
+        String overrideLocation = "?expires=" + expiresAt + "&sig=" + signature;
         String requestQS = request.getQueryString();
         if (requestQS != null) {
-            overrideLocation += "&" + requestQS;
+            requestQS = "&" + requestQS;
+            int expiryIdx = requestQS.indexOf("&expiry=");
+            int nextParamIdx = requestQS.indexOf('&', expiryIdx + 1);
+            if (expiryIdx != -1) {
+                String otherQS = requestQS.substring(0, expiryIdx);
+                if (nextParamIdx != -1) {
+                    otherQS += requestQS.substring(nextParamIdx);
+                }
+                requestQS = otherQS;
+            }
+            overrideLocation += requestQS;
         }
         if (request.getMethod() == "GET") {
             response.setStatus(302);
             response.setHeader("Location", overrideLocation);
             return null;
         } else {
-            return overrideLocation;
+            return request.getRequestURI() + overrideLocation;
         }
     }
 }

--- a/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
+++ b/src/main/java/eu/openanalytics/controllers/AppOverrideController.java
@@ -172,14 +172,14 @@ public class AppOverrideController extends BaseController {
 			response.setContentType("text/plain");
 			return "Not Implemented: tag overriding is either disabled or failed to intialize";
 		}
-		long configExpiry = ((long) tagOverrideService.getTagOverrideExpirationDays()) * 1000 * 60 * 60 * 24;
+		long maxExpiry = ((long) tagOverrideService.getMaxTagOverrideExpirationDays()) * 1000 * 60 * 60 * 24;
 		if (expiry == null) {
-			expiry = configExpiry;
-		} else if (configExpiry > 0) {
+			expiry = ((long) tagOverrideService.getDefaultTagOverrideExpirationDays()) * 1000 * 60 * 60 * 24;
+		} else if (maxExpiry > 0) {
 			if (expiry > 0) {
-				expiry = Math.min(expiry, configExpiry);
+				expiry = Math.min(expiry, maxExpiry);
 			} else {
-				expiry = configExpiry;
+				expiry = maxExpiry;
 			}
 		}
 		long expiresAt;

--- a/src/main/java/eu/openanalytics/controllers/BaseController.java
+++ b/src/main/java/eu/openanalytics/controllers/BaseController.java
@@ -58,7 +58,8 @@ public abstract class BaseController {
 	Environment environment;
 	
 	private static Logger logger = Logger.getLogger(BaseController.class);
-	private static Pattern appPattern = Pattern.compile(".*/app/(.*)");
+	private static Pattern appPattern = Pattern.compile(".*/app(?:Override)?/([^/?]*).*");
+	private static Pattern tagOverridePattern = Pattern.compile(".*/appOverride/[^/?]*/([^/?]*).*");
 	private static Map<String, String> imageCache = new HashMap<>();
 	
 	protected String getUserName(HttpServletRequest request) {
@@ -73,6 +74,16 @@ public abstract class BaseController {
 	
 	protected String getAppName(String uri) {
 		Matcher matcher = appPattern.matcher(uri);
+		String appName = matcher.matches() ? matcher.group(1) : null;
+		return appName;
+	}
+	
+	protected String getTagOverride(HttpServletRequest request) {
+		return getTagOverride(request.getRequestURI());
+	}
+	
+	protected String getTagOverride(String uri) {
+		Matcher matcher = tagOverridePattern.matcher(uri);
 		String appName = matcher.matches() ? matcher.group(1) : null;
 		return appName;
 	}

--- a/src/main/java/eu/openanalytics/controllers/BaseController.java
+++ b/src/main/java/eu/openanalytics/controllers/BaseController.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.log4j.Logger;
 import org.springframework.core.env.Environment;
@@ -58,8 +59,8 @@ public abstract class BaseController {
 	Environment environment;
 	
 	private static Logger logger = Logger.getLogger(BaseController.class);
-	private static Pattern appPattern = Pattern.compile(".*/app(?:Override)?/([^/?]*).*");
-	private static Pattern tagOverridePattern = Pattern.compile(".*/appOverride/[^/?]*/([^/?]*).*");
+	private static Pattern appPattern = Pattern.compile(".*/app(?:Override/[^/?#]*)?/(.*)");
+	private static Pattern tagOverridePattern = Pattern.compile(".*/appOverride/([^/?#]*).*");
 	private static Map<String, String> imageCache = new HashMap<>();
 	
 	protected String getUserName(HttpServletRequest request) {
@@ -127,5 +128,16 @@ public abstract class BaseController {
 		}
 		imageCache.put(resourceURI, resolvedValue);
 		return resolvedValue;
+	}
+
+	protected void sendSimpleResponse(HttpServletResponse response, int status, String message) {
+		try {
+			response.setStatus(status);
+			response.setContentType("text/plain");
+			response.getWriter().write(message);
+			response.getWriter().close();
+		} catch (IOException e) {
+			// Most likely the client closed the connection.
+		}
 	}
 }

--- a/src/main/java/eu/openanalytics/controllers/HeartbeatController.java
+++ b/src/main/java/eu/openanalytics/controllers/HeartbeatController.java
@@ -36,7 +36,7 @@ public class HeartbeatController extends BaseController {
 	
 	@RequestMapping("/heartbeat/**")
 	void heartbeat(HttpServletRequest request, HttpServletResponse response) {
-		userService.heartbeatReceived(getUserName(request), getAppName(request));
+		userService.heartbeatReceived(getUserName(request), getAppName(request), getTagOverride(request));
 		try {
 			response.setStatus(200);
 			response.setContentType("text/html");

--- a/src/main/java/eu/openanalytics/controllers/HeartbeatController.java
+++ b/src/main/java/eu/openanalytics/controllers/HeartbeatController.java
@@ -20,30 +20,20 @@
  */
 package eu.openanalytics.controllers;
 
-import java.io.IOException;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.log4j.Logger;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 public class HeartbeatController extends BaseController {
 
-	private Logger log = Logger.getLogger(HeartbeatController.class);
-	
 	@RequestMapping("/heartbeat/**")
-	void heartbeat(HttpServletRequest request, HttpServletResponse response) {
+	@ResponseBody
+	String heartbeat(HttpServletRequest request, HttpServletResponse response) {
 		userService.heartbeatReceived(getUserName(request), getAppName(request), getTagOverride(request));
-		try {
-			response.setStatus(200);
-			response.setContentType("text/html");
-			response.getWriter().write("Ok");
-			response.getWriter().flush();
-		} catch (IOException e) {
-			log.error("Failed to send heartbeat response", e);
-		}
+		return "Ok";
 	}
 }

--- a/src/main/java/eu/openanalytics/controllers/IndexController.java
+++ b/src/main/java/eu/openanalytics/controllers/IndexController.java
@@ -62,7 +62,7 @@ public class IndexController extends BaseController {
 		map.put("displayAppLogos", displayAppLogos);
 
 		boolean isAdmin = userService.isAdmin(authentication);
-		boolean canOverrideTags = isAdmin && tagOverrideService.getKeyPair() != null;
+		boolean canOverrideTags = isAdmin && tagOverrideService.getSecret() != null;
 		map.put("canOverrideTags", canOverrideTags);
 		if (canOverrideTags) {
 			map.put("maxTagOverrideExpirationDays", tagOverrideService.getMaxTagOverrideExpirationDays());

--- a/src/main/java/eu/openanalytics/services/AppService.java
+++ b/src/main/java/eu/openanalytics/services/AppService.java
@@ -21,6 +21,7 @@
 package eu.openanalytics.services;
 
 import eu.openanalytics.ShinyProxyApplication;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,10 +38,10 @@ import org.springframework.stereotype.Service;
 public class AppService {
 
 	private List<ShinyApp> apps = new ArrayList<>();
-	
+
 	@Inject
 	Environment environment;
-	
+
 	public ShinyApp getApp(String name) {
 		for (ShinyApp app: apps) {
 			if (app.getName().equals(name)) return app;
@@ -51,13 +52,13 @@ public class AppService {
 	public List<ShinyApp> getApps() {
 		return apps;
 	}
-	
+
 	public String buildContainerPath(String mapping, HttpServletRequest request) {
 		if (mapping == null) return "";
 		
 		String queryString = request.getQueryString();
 		queryString = (queryString == null) ? "" : "?" + queryString;
-		
+
 		String contextPath = ShinyProxyApplication.getContextPath(environment);
 		String containerPath = contextPath + "/" + mapping + environment.getProperty("shiny.proxy.landing-page") + queryString;
 		return containerPath;

--- a/src/main/java/eu/openanalytics/services/AppService.java
+++ b/src/main/java/eu/openanalytics/services/AppService.java
@@ -20,13 +20,14 @@
  */
 package eu.openanalytics.services;
 
+import eu.openanalytics.ShinyProxyApplication;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
-
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
@@ -51,6 +52,17 @@ public class AppService {
 		return apps;
 	}
 	
+	public String buildContainerPath(String mapping, HttpServletRequest request) {
+		if (mapping == null) return "";
+		
+		String queryString = request.getQueryString();
+		queryString = (queryString == null) ? "" : "?" + queryString;
+		
+		String contextPath = ShinyProxyApplication.getContextPath(environment);
+		String containerPath = contextPath + "/" + mapping + environment.getProperty("shiny.proxy.landing-page") + queryString;
+		return containerPath;
+	}
+
 	public static class ShinyApp {
 		
 		private String name;

--- a/src/main/java/eu/openanalytics/services/DockerService.java
+++ b/src/main/java/eu/openanalytics/services/DockerService.java
@@ -30,7 +30,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -90,13 +92,13 @@ public class DockerService {
 		
 	private Logger log = Logger.getLogger(DockerService.class);
 
-	private List<Proxy> launchingProxies = Collections.synchronizedList(new ArrayList<>());
-	private List<Proxy> activeProxies = Collections.synchronizedList(new ArrayList<>());
+	private Map<AppInstanceDetails, Proxy> proxies = new HashMap<>();
 	
 	private List<MappingListener> mappingListeners = Collections.synchronizedList(new ArrayList<>());
 	private Set<Integer> occupiedPorts = Collections.synchronizedSet(new HashSet<>());
 	
 	private ExecutorService containerKiller = Executors.newSingleThreadExecutor();
+	private boolean shuttingDown = false;
 	
 	private boolean swarmMode = false;
 	
@@ -118,6 +120,24 @@ public class DockerService {
 	@Inject
 	DockerClient dockerClient;
 
+	public static class AppInstanceDetails {
+		
+		public String userName;
+		public String appName;
+		public String tagOverride;
+
+		public AppInstanceDetails(String userName, String appName, String tagOverride) {
+			this.userName = userName;
+			this.appName = appName;
+			this.tagOverride = tagOverride;
+		}
+
+		public AppInstanceDetails(String userName, String appName) {
+			this.userName = userName;
+			this.appName = appName;
+		}
+	}
+
 	public static class Proxy {
 		
 		public String name;
@@ -130,7 +150,15 @@ public class DockerService {
 		public String appName;
 		public String tagOverride;
 		public String sessionId;
+		public boolean launching;
 		public long startupTimestamp;
+
+		public Proxy(AppInstanceDetails details) {
+			this.userName = details.userName;
+			this.appName = details.appName;
+			this.tagOverride = details.tagOverride;
+			this.launching = true;
+		}
 		
 		public String uptime() {
 			long uptimeSec = (System.currentTimeMillis() - startupTimestamp)/1000;
@@ -162,12 +190,13 @@ public class DockerService {
 	
 	@PreDestroy
 	public void shutdown() {
+		shuttingDown = true;
 		containerKiller.shutdown();
-		List<Proxy> proxiesToRelease = new ArrayList<>();
-		synchronized (activeProxies) {
-			proxiesToRelease.addAll(activeProxies);
+		synchronized (proxies) {
+			for (Proxy proxy: proxies.values()) {
+				releaseProxy(proxy, false, false);
+			}
 		}
-		for (Proxy proxy: proxiesToRelease) releaseProxy(proxy, false);
 	}
 
 	@Bean
@@ -181,23 +210,17 @@ public class DockerService {
 			throw new ShinyProxyException("Failed to initialize docker client", e);
 		}
 	}
-	
-	public List<Proxy> listProxies() {
-		synchronized (activeProxies) {
-			return activeProxies.stream().map(p -> p.copyInto(new Proxy())).collect(Collectors.toList());
-		}
-	}
-	
-	public String getMapping(String userName, String appName, boolean startNew) {
-		return getMapping(userName, appName, null, startNew);
-	}
 
-	public String getMapping(String userName, String appName, String tagOverride, boolean startNew) {
-		waitForLaunchingProxy(userName, appName, tagOverride);
-		Proxy proxy = findProxy(userName, appName, tagOverride);
+	public Collection<Proxy> listProxies() {
+		return proxies.values();
+	}
+	
+	public String getMapping(AppInstanceDetails appDetails, boolean startNew) {
+		waitForLaunchingProxy(appDetails);
+		Proxy proxy = proxies.get(appDetails);
 		if (proxy == null && startNew) {
 			// The user has no proxy yet.
-			proxy = startProxy(userName, appName, tagOverride);
+			proxy = startProxy(appDetails);
 		}
 		return (proxy == null) ? null : proxy.name;
 	}
@@ -206,15 +229,8 @@ public class DockerService {
 		String sessionId = getCurrentSessionId(exchange);
 		if (sessionId == null) return false;
 		String proxyName = exchange.getRelativePath();
-		synchronized (activeProxies) {
-			for (Proxy p: activeProxies) {
-				if (p.sessionId.equals(sessionId) && proxyName.startsWith("/" + p.name)) {
-					return true;
-				}
-			}
-		}
-		synchronized (launchingProxies) {
-			for (Proxy p: launchingProxies) {
+		synchronized (proxies) {
+			for (Proxy p: proxies.values()) {
 				if (p.sessionId.equals(sessionId) && proxyName.startsWith("/" + p.name)) {
 					return true;
 				}
@@ -225,19 +241,12 @@ public class DockerService {
 	
 	public void releaseProxies(String userName) {
 		List<Proxy> proxiesToRelease = new ArrayList<>();
-		synchronized (activeProxies) {
-			for (Proxy proxy: activeProxies) {
+		synchronized (proxies) {
+			for (Proxy proxy: proxies.values()) {
 				if (userName.equals(proxy.userName)) proxiesToRelease.add(proxy);
 			}
 		}
 		for (Proxy proxy: proxiesToRelease) {
-			releaseProxy(proxy, true);
-		}
-	}
-	
-	public void releaseProxy(String userName, String appName, String tagOverride) {
-		Proxy proxy = findProxy(userName, appName, tagOverride);
-		if (proxy != null) {
 			releaseProxy(proxy, true);
 		}
 	}
@@ -251,9 +260,18 @@ public class DockerService {
 		if (sessionCookie == null) return null;
 		return sessionCookie.getValue();
 	}
+
+	public void releaseProxy(Proxy proxy, boolean async) {
+		releaseProxy(proxy, async, true);
+	}
 	
-	private void releaseProxy(Proxy proxy, boolean async) {
-		activeProxies.remove(proxy);
+	private void releaseProxy(Proxy proxy, boolean async, boolean removeFromList) {
+		if (removeFromList) {
+			synchronized (proxies) {
+				if (!proxies.containsValue(proxy)) return;
+				while (proxies.values().remove(proxy));
+			}
+		}
 		
 		Runnable releaser = () -> {
 			try {
@@ -285,31 +303,31 @@ public class DockerService {
 		}
 	}
 	
-	private Proxy startProxy(String userName, String appName, String tagOverride) {
-		ShinyApp app = appService.getApp(appName);
+	private Proxy startProxy(AppInstanceDetails details) {
+		ShinyApp app = appService.getApp(details.appName);
 		if (app == null) {
-			throw new ShinyProxyException("Cannot start container: unknown application: " + appName);
+			throw new ShinyProxyException("Cannot start container: unknown application: " + details.appName);
 		}
 		
-		if (findProxy(userName, appName, tagOverride) != null) {
-			throw new ShinyProxyException("Cannot start container: user " + userName + " already has a running proxy");
+		if (proxies.get(details) != null) {
+			throw new ShinyProxyException("Cannot start container: user " + details.userName + " already has a running proxy");
 		}
 		
-		Proxy proxy = new Proxy();
-		proxy.userName = userName;
-		proxy.appName = appName;
-		proxy.tagOverride = tagOverride;
+		Proxy proxy = new Proxy(details);
 		proxy.port = getFreePort();
 		proxy.sessionId = getCurrentSessionId(null);
-		launchingProxies.add(proxy);
+		synchronized (proxies) {
+			if (shuttingDown) throw new ShinyProxyException("Cannot start container: already shutting down");
+			proxies.put(details, proxy);
+		}
 		
 		String dockerImage = app.getDockerImage();
-		if (tagOverride != null) {
+		if (details.tagOverride != null) {
 			int idx = dockerImage.indexOf(':');
 			if (idx == -1) {
-				dockerImage += ':' + tagOverride;
+				dockerImage += ':' + details.tagOverride;
 			} else {
-				dockerImage = dockerImage.substring(0, idx + 1) + tagOverride;
+				dockerImage = dockerImage.substring(0, idx + 1) + details.tagOverride;
 			}
 		}
 
@@ -326,7 +344,7 @@ public class DockerService {
 				ContainerSpec containerSpec = ContainerSpec.builder()
 						.image(dockerImage)
 						.command(app.getDockerCmd())
-						.env(buildEnv(userName, app))
+						.env(buildEnv(details.userName, app))
 						.dnsConfig(DnsConfig.builder().nameServers(app.getDockerDns()).build())
 						.mounts(mounts)
 						.build();
@@ -384,7 +402,7 @@ public class DockerService {
 					    .image(dockerImage)
 					    .exposedPorts("3838")
 					    .cmd(app.getDockerCmd())
-					    .env(buildEnv(userName, app))
+					    .env(buildEnv(details.userName, app))
 					    .build();
 				
 				ContainerCreation container = dockerClient.createContainer(containerConfig);
@@ -404,13 +422,12 @@ public class DockerService {
 			proxy.startupTimestamp = System.currentTimeMillis();
 		} catch (Exception e) {
 			releasePort(proxy.port);
-			launchingProxies.remove(proxy);
+			proxies.remove(details);
 			throw new ShinyProxyException("Failed to start container: " + e.getMessage(), e);
 		}
 
 		if (!testProxy(proxy)) {
 			releaseProxy(proxy, true);
-			launchingProxies.remove(proxy);
 			throw new ShinyProxyException("Container did not respond in time");
 		}
 		
@@ -434,39 +451,22 @@ public class DockerService {
 			}
 		}
 		
-		activeProxies.add(proxy);
-		launchingProxies.remove(proxy);
-		log.info(String.format("Proxy activated [user: %s] [app: %s] [tagOverride: %s] [port: %d]", userName, appName, tagOverride, proxy.port));
+		proxy.launching = false;
+		log.info(String.format("Proxy activated [user: %s] [app: %s] [tagOverride: %s] [port: %d]", details.userName, details.appName, details.tagOverride, proxy.port));
 		// TODO add tagOverride
-		eventService.post(EventType.AppStart.toString(), userName, appName);
+		eventService.post(EventType.AppStart.toString(), details.userName, details.appName);
 		
 		return proxy;
 	}
 	
-	private Proxy findProxy(String userName, String appName, String tagOverride) {
-		return findProxy(userName, appName, tagOverride, activeProxies);
-	}
-	
-	private Proxy findProxy(String userName, String appName, String tagOverride, List<Proxy> proxyList) {
-		synchronized (activeProxies) {
-			for (Proxy proxy: proxyList) {
-				if (userName.equals(proxy.userName) && appName.equals(proxy.appName) &&
-					(tagOverride == null ? proxy.tagOverride == null : tagOverride.equals(proxy.tagOverride))
-				) {
-					return proxy;
-				}
-			}
-		}
-		return null;
-	}
-	
-	private void waitForLaunchingProxy(String userName, String appName, String tagOverride) {
+	private void waitForLaunchingProxy(AppInstanceDetails details) {
 		int totalWaitMs = Integer.parseInt(environment.getProperty("shiny.proxy.container-wait-time", "20000"));
 		int waitMs = Math.min(2000, totalWaitMs);
 		int maxTries = totalWaitMs / waitMs;
 		
 		boolean mayProceed = retry(i -> {
-			return findProxy(userName, appName, tagOverride, launchingProxies) == null;
+			Proxy proxy = proxies.get(details);
+			return proxy == null || !proxy.launching;
 		}, maxTries, waitMs);
 		
 		if (!mayProceed) throw new ShinyProxyException("Cannot proceed: waiting for proxy to launch");

--- a/src/main/java/eu/openanalytics/services/DockerService.java
+++ b/src/main/java/eu/openanalytics/services/DockerService.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -50,6 +51,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.log4j.Logger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
@@ -135,6 +137,27 @@ public class DockerService {
 		public AppInstanceDetails(String userName, String appName) {
 			this.userName = userName;
 			this.appName = appName;
+		}
+
+		@Override
+		public int hashCode() {
+			return new HashCodeBuilder()
+				.append(userName)
+				.append(appName)
+				.append(tagOverride)
+				.toHashCode();
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) return true;
+			if (obj == null) return false;
+			if (this.getClass() != obj.getClass()) return false;
+			AppInstanceDetails other = (AppInstanceDetails) obj;
+			if (!Objects.equals(userName, other.userName)) return false;
+			if (!Objects.equals(appName, other.appName)) return false;
+			if (!Objects.equals(tagOverride, other.tagOverride)) return false;
+			return true;
 		}
 	}
 

--- a/src/main/java/eu/openanalytics/services/SecretService.java
+++ b/src/main/java/eu/openanalytics/services/SecretService.java
@@ -1,0 +1,91 @@
+/**
+ * ShinyProxy
+ *
+ * Copyright (C) 2016-2017 Open Analytics
+ *
+ * ===========================================================================
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License as published by
+ * The Apache Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License
+ * along with this program.  If not, see <http://www.apache.org/licenses/>
+ */
+package eu.openanalytics.services;
+
+import com.google.common.collect.Sets;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Service;
+
+@Service
+// TODO: (US) Secret Service joke
+public class SecretService {
+	private Logger log = Logger.getLogger(TagOverrideService.class);
+
+    // value is null: means never been initialized
+    // value is optional, but optional is "null": means initialization failed
+    private Map<String, Optional<byte[]>> secrets = new HashMap<>();
+
+    private byte[] getSecretWithoutCache(String filename) {
+        File secretFile = new File(filename);
+        if (secretFile.exists()) {
+            try (FileInputStream fileStream = new FileInputStream(secretFile)) {
+                return Files.readAllBytes(secretFile.toPath());
+            } catch (Exception e) {
+                log.error("Failed to read secret, though it exists", e);
+            }
+        }
+        byte[] secret;
+        try {
+            SecureRandom rng = SecureRandom.getInstance("SHA1PRNG");
+            secret = new byte[2048];
+            rng.nextBytes(secret);
+        } catch (Exception e) {
+            log.error("Failed to generate secret", e);
+            return null;
+        }
+        try (FileOutputStream fileStream = new FileOutputStream(secretFile)) {
+            Files.setPosixFilePermissions(secretFile.toPath(), Sets.newHashSet(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+            fileStream.write(secret);
+        } catch (Exception e) {
+            log.error("Failed to write secret (or set permissions)", e);
+        }
+        return secret;
+    }
+
+    public byte[] getSecret(String filename) {
+        synchronized(secrets) {
+            Optional<byte[]> secret = secrets.get(filename);
+            if (secret != null) {
+                return secret.orElse(null);
+            }
+            byte[] newSecret = getSecretWithoutCache(filename);
+            secrets.put(filename, Optional.ofNullable(newSecret));
+            return newSecret;
+        }
+    }
+
+    public Thread warmupCache(String filename) {
+        Thread thread = new Thread(() -> getSecret(filename));
+        thread.start();
+        return thread;
+    }
+
+}

--- a/src/main/java/eu/openanalytics/services/TagOverrideService.java
+++ b/src/main/java/eu/openanalytics/services/TagOverrideService.java
@@ -74,10 +74,10 @@ public class TagOverrideService {
 			}
 		}
 		try {
-			SecureRandom rng = SecureRandom.getInstanceStrong();
-			KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DSA");
+			SecureRandom rng = SecureRandom.getInstance("SHA1PRNG");
+			KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
 			log.info("Generating tag override key pair. This may take a while...");
-			keyGen.initialize(1024, rng);
+			keyGen.initialize(2048, rng);
 			keyPair = keyGen.generateKeyPair();
 		} catch (Exception e) {
 			log.error("Failed to generate override key pair", e);

--- a/src/main/java/eu/openanalytics/services/TagOverrideService.java
+++ b/src/main/java/eu/openanalytics/services/TagOverrideService.java
@@ -47,8 +47,18 @@ public class TagOverrideService {
 	@Inject
 	Environment environment;
 
-	public int getTagOverrideExpirationDays() {
-		return Integer.parseInt(environment.getProperty("shiny.proxy.tag-overriding.expiration-days", "7"));
+	public int getMaxTagOverrideExpirationDays() {
+		return Integer.parseInt(environment.getProperty("shiny.proxy.tag-overriding.max-expiration-days", "7"));
+	}
+
+	public int getDefaultTagOverrideExpirationDays() {
+		int defaultDays = Integer.parseInt(environment.getProperty("shiny.proxy.tag-overriding.default-expiration-days", "7"));
+		int maxDays = getMaxTagOverrideExpirationDays();
+		if (maxDays <= 0) {
+			return defaultDays;
+		} else {
+			return Math.min(maxDays, defaultDays);
+		}
 	}
 
 	public KeyPair getKeyPair() {

--- a/src/main/java/eu/openanalytics/services/TagOverrideService.java
+++ b/src/main/java/eu/openanalytics/services/TagOverrideService.java
@@ -54,8 +54,8 @@ public class TagOverrideService {
 		return Integer.parseInt(environment.getProperty("shiny.proxy.tag-overriding.minimum-signature-bytes", "16"));
 	}
 
-	public int getURLSigLen() {
-		return Integer.parseInt(environment.getProperty("shiny.proxy.tag-overriding.url-signature-bytes", "16"));
+	public int getDefaultSigLen() {
+		return Integer.parseInt(environment.getProperty("shiny.proxy.tag-overriding.default-signature-bytes", "16"));
 	}
 
 	public int getDefaultTagOverrideExpirationDays() {

--- a/src/main/java/eu/openanalytics/services/TagOverrideService.java
+++ b/src/main/java/eu/openanalytics/services/TagOverrideService.java
@@ -1,0 +1,95 @@
+/**
+ * ShinyProxy
+ *
+ * Copyright (C) 2016-2017 Open Analytics
+ *
+ * ===========================================================================
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Apache License as published by
+ * The Apache Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Apache License for more details.
+ *
+ * You should have received a copy of the Apache License
+ * along with this program.  If not, see <http://www.apache.org/licenses/>
+ */
+package eu.openanalytics.services;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.apache.log4j.Logger;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TagOverrideService {
+
+	private Logger log = Logger.getLogger(TagOverrideService.class);
+
+	private KeyPair keyPair;
+
+	@Inject
+	Environment environment;
+
+	public int getTagOverrideExpirationDays() {
+		return Integer.parseInt(environment.getProperty("shiny.proxy.tag-overriding.expiration-days", "7"));
+	}
+
+	public KeyPair getKeyPair() {
+		return keyPair;
+	}
+
+	@PostConstruct
+	private void initKeyPair() {
+		if (environment.getProperty("shiny.proxy.tag-overriding.enabled", "").equals("")) {
+			log.info("Tag overriding disabled");
+			return;
+		}
+		log.info("Tag overriding enabled");
+		File keyFileFile = new File(environment.getProperty("shiny.proxy.tag-overriding.key-file", "tagOverrideKey.ser"));
+		if (keyFileFile.exists()) {
+			try (FileInputStream fileStream = new FileInputStream(keyFileFile)) {
+				try (ObjectInputStream objectStream = new ObjectInputStream(fileStream)) {
+					keyPair = (KeyPair) objectStream.readObject();
+					return;
+				}
+			} catch (Exception e) {
+				log.error("Failed to read override key file", e);
+			}
+		}
+		try {
+			SecureRandom rng = SecureRandom.getInstanceStrong();
+			KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DSA");
+			log.info("Generating tag override key pair. This may take a while...");
+			keyGen.initialize(1024, rng);
+			keyPair = keyGen.generateKeyPair();
+		} catch (Exception e) {
+			log.error("Failed to generate override key pair", e);
+			return;
+		}
+		try (FileOutputStream fileStream = new FileOutputStream(keyFileFile)) {
+			try (ObjectOutputStream objectStream = new ObjectOutputStream(fileStream)) {
+				objectStream.writeObject(keyPair);
+			}
+		} catch (Exception e) {
+			log.error("Failed to write override key file", e);
+		}
+	}
+
+}

--- a/src/main/java/eu/openanalytics/services/UserService.java
+++ b/src/main/java/eu/openanalytics/services/UserService.java
@@ -155,8 +155,8 @@ public class UserService implements ApplicationListener<AbstractAuthenticationEv
 		eventService.post(EventType.Logout.toString(), userName, null);
 	}
 	
-	public void heartbeatReceived(String user, String app) {
-		heartbeatTimestamps.put(getKey(user, app), System.currentTimeMillis());
+	public void heartbeatReceived(String user, String app, String tagOverride) {
+		heartbeatTimestamps.put(getKey(user, app, tagOverride), System.currentTimeMillis());
 	}
 	
 	private class AppCleaner implements Runnable {
@@ -169,13 +169,13 @@ public class UserService implements ApplicationListener<AbstractAuthenticationEv
 				try {
 					long currentTimestamp = System.currentTimeMillis();
 					for (Proxy proxy: dockerService.listProxies()) {
-						HeartbeatKey key = getKey(proxy.userName, proxy.appName);
+						HeartbeatKey key = getKey(proxy.userName, proxy.appName, proxy.tagOverride);
 						Long lastHeartbeat = heartbeatTimestamps.get(key);
 						if (lastHeartbeat == null) lastHeartbeat = proxy.startupTimestamp;
 						long proxySilence = currentTimestamp - lastHeartbeat;
 						if (proxySilence > heartbeatTimeout) {
 							log.info(String.format("Releasing inactive proxy [user: %s] [app: %s] [silence: %dms]", proxy.userName, proxy.appName, proxySilence));
-							dockerService.releaseProxy(proxy.userName, proxy.appName);
+							dockerService.releaseProxy(proxy.userName, proxy.appName, proxy.tagOverride);
 							heartbeatTimestamps.remove(key);
 						}
 					}
@@ -189,8 +189,8 @@ public class UserService implements ApplicationListener<AbstractAuthenticationEv
 		}
 	}
 	
-	private HeartbeatKey getKey(String userName, String appName) {
-		return new HeartbeatKey(userName, appName);
+	private HeartbeatKey getKey(String userName, String appName, String tagOverride) {
+		return new HeartbeatKey(userName, appName, tagOverride);
 	}
 	
 	
@@ -198,10 +198,12 @@ public class UserService implements ApplicationListener<AbstractAuthenticationEv
 		
 		private String userName;
 		private String appName;
+		private String tagOverride;
 		
-		public HeartbeatKey(String userName, String appName) {
+		public HeartbeatKey(String userName, String appName, String tagOverride) {
 			this.userName = userName;
 			this.appName = appName;
+			this.tagOverride = tagOverride;
 		}
 
 		@Override
@@ -210,6 +212,7 @@ public class UserService implements ApplicationListener<AbstractAuthenticationEv
 			int result = 1;
 			result = prime * result + ((appName == null) ? 0 : appName.hashCode());
 			result = prime * result + ((userName == null) ? 0 : userName.hashCode());
+			result = prime * result + ((tagOverride == null) ? 0 : tagOverride.hashCode());
 			return result;
 		}
 

--- a/src/main/java/eu/openanalytics/services/UserService.java
+++ b/src/main/java/eu/openanalytics/services/UserService.java
@@ -175,7 +175,7 @@ public class UserService implements ApplicationListener<AbstractAuthenticationEv
 						long proxySilence = currentTimestamp - lastHeartbeat;
 						if (proxySilence > heartbeatTimeout) {
 							log.info(String.format("Releasing inactive proxy [user: %s] [app: %s] [silence: %dms]", proxy.userName, proxy.appName, proxySilence));
-							dockerService.releaseProxy(proxy.userName, proxy.appName, proxy.tagOverride);
+							dockerService.releaseProxy(proxy, true);
 							heartbeatTimestamps.remove(key);
 						}
 					}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -85,7 +85,7 @@
     "description": "The minimum number of bytes to check in an override \"signature\" (really just a hash)"
   },
   {
-    "name": "shiny.proxy.tag-overriding.url-signature-bytes",
+    "name": "shiny.proxy.tag-overriding.default-signature-bytes",
     "type": "int",
     "description": "The default number of \"signature\" bytes to put in an override URL"
   }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -58,5 +58,20 @@
     "name": "shiny.proxy.logo-url",
     "type": "java.lang.String",
     "description": "URL for the logo to use in the toolbar"
+  },
+  {
+    "name": "shiny.proxy.tag-overriding.enabled",
+    "type": "boolean",
+    "description": "If the tag overriding mechanism should be enabled"
+  },
+  {
+    "name": "shiny.proxy.tag-overriding.key-file",
+    "type": "java.lang.String",
+    "description": "The path to the serialized key pair for tag overriding (created if nonexistant)"
+  },
+  {
+    "name": "shiny.proxy.tag-overriding.expiration-days",
+    "type": "int",
+    "description": "The maximum amount of days before a tag override expires (or 0 for never)"
   }
 ]}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -70,8 +70,13 @@
     "description": "The path to the serialized key pair for tag overriding (created if nonexistant)"
   },
   {
-    "name": "shiny.proxy.tag-overriding.expiration-days",
+    "name": "shiny.proxy.tag-overriding.max-expiration-days",
     "type": "int",
     "description": "The maximum amount of days before a tag override expires (or 0 for never)"
+  },
+  {
+    "name": "shiny.proxy.tag-overriding.default-expiration-days",
+    "type": "int",
+    "description": "The default amount of days before a tag override expires (or 0 for never)"
   }
 ]}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -65,9 +65,9 @@
     "description": "If the tag overriding mechanism should be enabled"
   },
   {
-    "name": "shiny.proxy.tag-overriding.key-file",
+    "name": "shiny.proxy.tag-overriding.secret-file",
     "type": "java.lang.String",
-    "description": "The path to the serialized key pair for tag overriding (created if nonexistant)"
+    "description": "The path to the raw secret bytes for tag overriding (created if nonexistant)"
   },
   {
     "name": "shiny.proxy.tag-overriding.max-expiration-days",
@@ -78,5 +78,15 @@
     "name": "shiny.proxy.tag-overriding.default-expiration-days",
     "type": "int",
     "description": "The default amount of days before a tag override expires (or 0 for never)"
+  },
+  {
+    "name": "shiny.proxy.tag-overriding.minimum-signature-bytes",
+    "type": "int",
+    "description": "The minimum number of bytes to check in an override \"signature\" (really just a hash)"
+  },
+  {
+    "name": "shiny.proxy.tag-overriding.url-signature-bytes",
+    "type": "int",
+    "description": "The default number of \"signature\" bytes to put in an override URL"
   }
 ]}

--- a/src/main/resources/static/css/default.css
+++ b/src/main/resources/static/css/default.css
@@ -64,3 +64,7 @@ body > div#navbar { padding-top: 0px; }
 	font-size: 24px;
 	margin-top: -50px;
 }
+
+.get-link-output {
+	margin-top: 10px;
+}

--- a/src/main/resources/static/css/default.css
+++ b/src/main/resources/static/css/default.css
@@ -65,6 +65,6 @@ body > div#navbar { padding-top: 0px; }
 	margin-top: -50px;
 }
 
-.get-link-output {
+.get-link-output-group {
 	margin-top: 10px;
 }

--- a/src/main/resources/templates/app.html
+++ b/src/main/resources/templates/app.html
@@ -59,7 +59,7 @@
 			var source = $("#shinyframe").attr("src");
 			if (source == "") {
 				$(".loading").show();
-				$.post(window.location.pathname, function(containerPath) {
+				$.post(window.location.pathname + window.location.search, function(containerPath) {
 					$("#shinyframe").attr("src", containerPath);
 					$(".loading").fadeOut("slow");
 				}).fail(function(request) {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -42,6 +42,30 @@
 				<a th:href="@{/app/}+${app.name}" th:text="${app.displayName == null} ? ${app.name} : ${app.displayName}"></a>
 				<br th:if="${app.description != null}" />
 				<span th:if="${app.description != null}" th:text="${app.description}"></span>
+				<details th:if="${canOverrideTags}">
+					<summary style="display: list-item"><b>Tag Overriding</b></summary>
+					<form class="form-inline tag-override-form">
+						<input type="hidden" class="app-name" th:value="${app.name}"></input>
+						<input type="hidden" class="max-expiration-days" th:value="${maxTagOverrideExpirationDays}"></input>
+						<input type="hidden" class="default-expiration-days" th:value="${defaultTagOverrideExpirationDays}"></input>
+						<div class="form-group">
+							<label>Tag</label>
+							<input type="text" class="form-control tag-input" placeholder="latest" required="required" pattern="[^/?#]+"></input>
+						</div>
+						<div class="form-group">
+							<label>Expiration Date</label>
+							<div class="input-group">
+								<span class="input-group-addon" th:if="${maxTagOverrideExpirationDays &lt;= 0}">
+									<input type="checkbox" class="should-expire"></input>
+								</span>
+								<input type="date" class="form-control expiration-date"></input>
+							</div>
+						</div>
+						<button type="submit" class="btn btn-primary go-btn">Go</button>
+						<button type="button" class="btn btn-default get-link-btn">Get Link</button>
+						<input type="text" class="form-input get-link-output" style="display: none" readonly="readonly"></input>
+					</form>
+				</details>
 			</li>
 		</ul>
 	</div>
@@ -62,5 +86,74 @@
 			</div>
 		</div>
 	</div>
+
+	<script type="text/javascript">
+		$(".tag-override-form").each(function (idx, form) {
+			form = $(form);
+			var appName = form.find("input.app-name").val();
+			var maxExpirationDays = parseInt(form.find("input.max-expiration-days").val());
+			var defaultExpirationDays = parseInt(form.find("input.default-expiration-days").val());
+			var tagInput = form.find("input.tag-input");
+			var expireCheckbox = form.find("input.should-expire");
+			var expirationInput = form.find("input.expiration-date");
+			var goBtn = form.find("button.go-btn");
+			var getLinkBtn = form.find("button.get-link-btn");
+			var getLinkOutput = form.find(".get-link-output");
+			if (expireCheckbox) {
+				expireCheckbox.on("change", function () {
+					expirationInput.prop("disabled", !this.checked);
+				});
+			}
+			function formatDateForInput(date) {
+				return date.getFullYear() + "-" + (date.getMonth() + 1) + "-" + date.getDate();
+			}
+			expirationInput.attr("min", formatDateForInput(new Date()));
+			if (maxExpirationDays > 0) {
+				var maxDate = new Date(new Date().getTime() + (maxExpirationDays * 1000 * 60 * 60 * 24));
+				expirationInput.attr("max", formatDateForInput(maxDate));
+			}
+			if (defaultExpirationDays > 0) {
+				expireCheckbox.prop("checked", true);
+				expirationInput.prop("disabled", false);
+				var defaultDate = new Date(new Date().getTime() + (defaultExpirationDays * 1000 * 60 * 60 * 24));
+				expirationInput.prop("value", formatDateForInput(defaultDate));
+			} else {
+				expireCheckbox.prop("checked", false);
+				expirationInput.prop("disabled", true);
+			}
+			function getBaseLink() {
+				var expiry;
+				if (!expireCheckbox.length || expireCheckbox.val()) {
+					if (expirationInput.val()) {
+						expiry = new Date(expirationInput.val()).getTime() + (new Date().getTimezoneOffset() * 1000 * 60) - new Date().getTime();
+					}
+				} else {
+					expiry = 0;
+				}
+				var tag = tagInput.val();
+				if (!tag) throw "Tag not specified";
+				var url = "/appOverride/" + tag + "/" + appName;
+				if (expiry !== undefined) url += "?expiry=" + expiry;
+				return url;
+			}
+			form.on("submit", function (evt) {
+				evt.preventDefault();
+				window.location.href = getBaseLink();
+				return false;
+			});
+			getLinkBtn.on("click", function () {
+				$.post(getBaseLink(), function (link) {
+					getLinkOutput.val(link);
+					getLinkOutput.css("display", "block");
+					try {
+						getLinkOutput.select();
+						document.execCommand("copy");
+					} catch (e) {
+						console.error("Failed to copy link to clipboard", e);
+					}
+				});
+			});
+		});
+	</script>
 </body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -105,7 +105,7 @@
 				});
 			}
 			function formatDateForInput(date) {
-				return date.getFullYear() + "-" + (date.getMonth() + 1) + "-" + date.getDate();
+				return date.toISOString().split("T")[0];
 			}
 			expirationInput.attr("min", formatDateForInput(new Date()));
 			if (maxExpirationDays > 0) {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -44,27 +44,39 @@
 				<span th:if="${app.description != null}" th:text="${app.description}"></span>
 				<details th:if="${canOverrideTags}">
 					<summary style="display: list-item"><b>Tag Overriding</b></summary>
-					<form class="form-inline tag-override-form">
-						<input type="hidden" class="app-name" th:value="${app.name}"></input>
-						<input type="hidden" class="max-expiration-days" th:value="${maxTagOverrideExpirationDays}"></input>
-						<input type="hidden" class="default-expiration-days" th:value="${defaultTagOverrideExpirationDays}"></input>
-						<div class="form-group">
-							<label>Tag</label>
-							<input type="text" class="form-control tag-input" placeholder="latest" required="required" pattern="[^/?#]+"></input>
-						</div>
-						<div class="form-group">
-							<label>Expiration Date</label>
-							<div class="input-group">
-								<span class="input-group-addon" th:if="${maxTagOverrideExpirationDays &lt;= 0}">
-									<input type="checkbox" class="should-expire"></input>
+					<div class="tag-override-form">
+						<form class="form-inline tag-override-form">
+							<input type="hidden" class="app-name" th:value="${app.name}"></input>
+							<input type="hidden" class="max-expiration-days" th:value="${maxTagOverrideExpirationDays}"></input>
+							<input type="hidden" class="default-expiration-days" th:value="${defaultTagOverrideExpirationDays}"></input>
+							<div class="form-group">
+								<label>Tag</label>
+								<input type="text" class="form-control tag-input" placeholder="latest" required="required" pattern="[^/?#]+"></input>
+							</div>
+							<div class="form-group">
+								<label>Expiration Date</label>
+								<div class="input-group">
+									<span class="input-group-addon" th:if="${maxTagOverrideExpirationDays &lt;= 0}">
+										<input type="checkbox" class="should-expire"></input>
+									</span>
+									<input type="date" class="form-control expiration-date"></input>
+								</div>
+							</div>
+							<button type="submit" class="btn btn-primary go-btn">Go</button>
+							<button type="button" class="btn btn-default get-link-btn">Get Link</button>
+							<br style="clear: both"></br>
+						</form>
+						<div class="col-lg-4">
+							<div class="input-group get-link-output-group" style="display: none">
+								<input type="text" class="form-control get-link-output" readonly="readonly"></input>
+								<span class="input-group-btn">
+									<button type="button" class="btn btn-default copy-link-btn">
+										<span class="glyphicon glyphicon-copy"></span>
+									</button>
 								</span>
-								<input type="date" class="form-control expiration-date"></input>
 							</div>
 						</div>
-						<button type="submit" class="btn btn-primary go-btn">Go</button>
-						<button type="button" class="btn btn-default get-link-btn">Get Link</button>
-						<input type="text" class="form-input get-link-output" style="display: none" readonly="readonly"></input>
-					</form>
+					</div>
 				</details>
 			</li>
 		</ul>
@@ -99,6 +111,8 @@
 			var goBtn = form.find("button.go-btn");
 			var getLinkBtn = form.find("button.get-link-btn");
 			var getLinkOutput = form.find(".get-link-output");
+			var getLinkOutputGroup = form.find(".get-link-output-group");
+			var copyLinkBtn = form.find("button.copy-link-btn");
 			if (expireCheckbox) {
 				expireCheckbox.on("change", function () {
 					expirationInput.prop("disabled", !this.checked);
@@ -127,11 +141,18 @@
 					if (expirationInput.val()) {
 						expiry = new Date(expirationInput.val()).getTime() + (new Date().getTimezoneOffset() * 1000 * 60) - new Date().getTime();
 					}
+					// Not valid XML with a less than or equal to
+					if (!(expiry > 0)) {
+						expiry = 1;
+					}
 				} else {
 					expiry = 0;
 				}
 				var tag = tagInput.val();
-				if (!tag) throw "Tag not specified";
+				if (!tag) {
+					goBtn.click(); // Should show a validation message
+					throw "Tag not specified";
+				}
 				var url = "/appOverride/" + tag + "/" + appName;
 				if (expiry !== undefined) url += "?expiry=" + expiry;
 				return url;
@@ -141,16 +162,15 @@
 				window.location.href = getBaseLink();
 				return false;
 			});
+			copyLinkBtn.on("click", function () {
+				getLinkOutput.select();
+				document.execCommand("copy");
+			});
 			getLinkBtn.on("click", function () {
-				$.post(getBaseLink(), function (link) {
-					getLinkOutput.val(link);
-					getLinkOutput.css("display", "block");
-					try {
-						getLinkOutput.select();
-						document.execCommand("copy");
-					} catch (e) {
-						console.error("Failed to copy link to clipboard", e);
-					}
+				$.post(getBaseLink(), function (url) {
+					getLinkOutput.val(window.location.origin + url);
+					getLinkOutputGroup.css("display", "");
+					getLinkOutput.select();
 				});
 			});
 		});

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -136,17 +136,17 @@
 				expirationInput.prop("disabled", true);
 			}
 			function getBaseLink() {
-				var expiry;
+				var expireAt;
 				if (!expireCheckbox.length || expireCheckbox.val()) {
 					if (expirationInput.val()) {
-						expiry = new Date(expirationInput.val()).getTime() + (new Date().getTimezoneOffset() * 1000 * 60) - new Date().getTime();
+						expireAt = new Date(expirationInput.val()).getTime() + (new Date().getTimezoneOffset() * 1000 * 60);
 					}
 					// Not valid XML with a less than or equal to
-					if (!(expiry > 0)) {
-						expiry = 1;
+					if (!(expireAt > 0)) {
+						expireAt = 1;
 					}
 				} else {
-					expiry = 0;
+					expireAt = 0;
 				}
 				var tag = tagInput.val();
 				if (!tag) {
@@ -154,7 +154,7 @@
 					throw "Tag not specified";
 				}
 				var url = "/appOverride/" + tag + "/" + appName;
-				if (expiry !== undefined) url += "?expiry=" + expiry;
+				if (expireAt !== undefined) url += "?expireAt=" + expireAt;
 				return url;
 			}
 			form.on("submit", function (evt) {


### PR DESCRIPTION
# Explanation of the feature

Administrators can generate a URL to an application, that will be the same as the normal URL, except a different Docker image tag will be used. This is preferable to modifying the application.yml because it can be automated and does not require restarting Shinyproxy.

# Use case

Say our application.yml has this:

```yaml
  apps:
  - name: ourCompanyApp
    docker-image: ourCompany/app
    ...
```

Then, we push a new image, `ourCompany/app:testingAmazingFeature` (this may be automated), and we want to test it out. To do this, we would previously have to modify the application.yml and restart Shinyproxy. This gets even more complicated when we're working on multiple features simultaniously. In addition, we'd like to automate this, and automating it through application.yml causes a number of problems.

# Config section

```yaml
shiny:
  proxy:
    tag-overriding:
      enabled: true # default false
      secret-file: /path/to/secret # stored as raw bytes, default tagOverride.secret
      max-expiration-days: 0 # less than or equal to 0 means infinite, default 8
      default-expiration-days: 7 # default 7
      minimum-signature-bytes: 8 # the server will not accept less bytes than this (use to gradually roll out a bigger signature), default 8
      default-signature-bytes: 16 # the server will generate a URL with this many bytes, default 8
```

# API Endpoints

All unix timestamps are in milliseconds (so 1000 times a normal unix timestamp).

`GET|POST /appOverride/[app name]/[image tag]?expires=[expiration unix timestamp]&sig=[url safe base64 signature]` first checks that the signature is valid and the current time is before the expiration timestamp, then behaves like `GET|POST /app/[app name]` but overrides the image tag
`GET /appOverride/[app name]/[image tag]?expireAt=[unix timestamp]` generates a signature clamping the expiration with config values and redirects (if the user is an admin)
`POST /appOverride/[app name]/[image tag]?expireAt=[unix timestamp]` generates a signature clamping the expiration with config values and returns the URL as the response body (again, if the user is an admin)

# "Signature" security technical details

The "signature" was an actual signature at one point, but now it's just part of a SHA256 hash. This is because signatures were way too long to reasonably fit in a URL. With SHA256 we can choose any amount of bytes (up to 32, defaults to 8). The SHA256 hash format is of `<app name>\0<tag name>\0<expiration unix timestamp in milliseconds - 8 bytes big endian>\0<secret>`. By default, the secret is stored as raw bytes in `tagOverride.secret` and is randomly generated with length 2048 bytes and permissions `0600` if it does not exist. I've also included a Python script `gen_tag_override.py` which generates a "signature" outside of Shinyproxy.