### PR TITLE
Fix querystring in containerPath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>eu.openanalytics</groupId>
 	<artifactId>shinyproxy</artifactId>
-	<version>1.0.3-SNAPSHOT</version>
+	<version>1.0.2</version>
 	<packaging>jar</packaging>
 
 	<name>shinyproxy</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>eu.openanalytics</groupId>
 	<artifactId>shinyproxy</artifactId>
-	<version>1.0.2</version>
+	<version>1.1.0</version>
 	<packaging>jar</packaging>
 
 	<name>shinyproxy</name>

--- a/src/main/resources/templates/app.html
+++ b/src/main/resources/templates/app.html
@@ -59,7 +59,7 @@
 			var source = $("#shinyframe").attr("src");
 			if (source == "") {
 				$(".loading").show();
-				$.post(window.location.pathname, function(containerPath) {
+				$.post(window.location.pathname + window.location.search, function(containerPath) {
 					$("#shinyframe").attr("src", containerPath);
 					$(".loading").fadeOut("slow");
 				}).fail(function(request) {


### PR DESCRIPTION
This PR fixes the issue when there is a queryString associated with the request URL. Without this fix requests such as /app/myApp?x=y don't get properly translated and the ?x=y part is not passed to the iframe.