### PR TITLE
the uptime in the admin panel should display 0 for still initializing apps

### DIFF
--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/AdminController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/AdminController.java
@@ -42,7 +42,11 @@ public class AdminController extends BaseController {
 		List<Proxy> proxies = proxyService.getProxies(null, false);
 		Map<String, String> proxyUptimes = new HashMap<>();
 		for (Proxy proxy: proxies) {
-			long uptimeSec = (System.currentTimeMillis() - proxy.getStartupTimestamp())/1000;
+			long uptimeSec = 0;
+			// if the proxy hasn't started up yet, the uptime should be zero
+			if (proxy.getStartupTimestamp() > 0) {
+				uptimeSec = (System.currentTimeMillis() - proxy.getStartupTimestamp())/1000;
+			}
 			String uptime = String.format("%d:%02d:%02d", uptimeSec/3600, (uptimeSec%3600)/60, uptimeSec%60);
 			proxyUptimes.put(proxy.getId(), uptime);
 		}


### PR DESCRIPTION
At present the `uptime` field displays a very big number, if you launch an app and go to admin panel immediately:

![image](https://user-images.githubusercontent.com/8368933/53382108-0b687a80-39ae-11e9-8c65-a856d09af991.png)

After this fix, it displays zero.