### PR TITLE
Enable to build a navbar menu that display app links

### DIFF
--- a/src/main/java/eu/openanalytics/shinyproxy/ShinyProxySpecProvider.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/ShinyProxySpecProvider.java
@@ -67,6 +67,7 @@ public class ShinyProxySpecProvider implements IProxySpecProvider {
 		ProxySpec to = new ProxySpec();
 		to.setId(from.getId());
 		to.setDisplayName(from.getDisplayName());
+		to.setDisplayGroup(from.getDisplayGroup());
 		to.setDescription(from.getDescription());
 		to.setLogoURL(from.getLogoURL());
 		
@@ -105,6 +106,7 @@ public class ShinyProxySpecProvider implements IProxySpecProvider {
 		
 		private String id;
 		private String displayName;
+		private String displayGroup;
 		private String description;
 		private String logoURL;
 		
@@ -138,6 +140,14 @@ public class ShinyProxySpecProvider implements IProxySpecProvider {
 			this.displayName = displayName;
 		}
 
+		public String getDisplayGroup() {
+			return displayGroup;
+		}
+
+		public void setDisplayGroup(String displayGroup) {
+			this.displayGroup = displayGroup;
+		}
+		
 		public String getDescription() {
 			return description;
 		}

--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/AdminController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/AdminController.java
@@ -31,6 +31,7 @@ import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import eu.openanalytics.containerproxy.model.runtime.Proxy;
+import eu.openanalytics.containerproxy.model.spec.ProxySpec;
 
 @Controller
 public class AdminController extends BaseController {
@@ -50,6 +51,9 @@ public class AdminController extends BaseController {
 		map.put("proxies", proxies);
 		map.put("proxyUptimes", proxyUptimes);
 		
+		ProxySpec[] apps = proxyService.getProxySpecs(null, false).toArray(new ProxySpec[0]);
+		map.put("apps", apps);
+
 		return "admin";
 	}
 }

--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/AdminController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/AdminController.java
@@ -23,6 +23,8 @@ package eu.openanalytics.shinyproxy.controllers;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -54,6 +56,12 @@ public class AdminController extends BaseController {
 		ProxySpec[] apps = proxyService.getProxySpecs(null, false).toArray(new ProxySpec[0]);
 		map.put("apps", apps);
 
+		Set<String> displayGroups = new HashSet<>();
+		for (ProxySpec app: apps) {
+			displayGroups.add(app.getDisplayGroup());
+		}
+		map.put("displayGroups", displayGroups.toArray(new String[0]));
+		
 		return "admin";
 	}
 }

--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/AdminController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/AdminController.java
@@ -23,7 +23,7 @@ package eu.openanalytics.shinyproxy.controllers;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
@@ -56,7 +56,7 @@ public class AdminController extends BaseController {
 		ProxySpec[] apps = proxyService.getProxySpecs(null, false).toArray(new ProxySpec[0]);
 		map.put("apps", apps);
 
-		Set<String> displayGroups = new HashSet<>();
+		Set<String> displayGroups = new LinkedHashSet<>();
 		for (ProxySpec app: apps) {
 			displayGroups.add(app.getDisplayGroup());
 		}

--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/AppController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/AppController.java
@@ -21,7 +21,9 @@
 package eu.openanalytics.shinyproxy.controllers;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -58,6 +60,12 @@ public class AppController extends BaseController {
 		ProxySpec[] apps = proxyService.getProxySpecs(null, false).toArray(new ProxySpec[0]);
 		map.put("apps", apps);
 
+		Set<String> displayGroups = new HashSet<>();
+		for (ProxySpec app: apps) {
+			displayGroups.add(app.getDisplayGroup());
+		}
+		map.put("displayGroups", displayGroups.toArray(new String[0]));
+				
 		return "app";
 	}
 	

--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/AppController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/AppController.java
@@ -21,7 +21,7 @@
 package eu.openanalytics.shinyproxy.controllers;
 
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -60,7 +60,7 @@ public class AppController extends BaseController {
 		ProxySpec[] apps = proxyService.getProxySpecs(null, false).toArray(new ProxySpec[0]);
 		map.put("apps", apps);
 
-		Set<String> displayGroups = new HashSet<>();
+		Set<String> displayGroups = new LinkedHashSet<>();
 		for (ProxySpec app: apps) {
 			displayGroups.add(app.getDisplayGroup());
 		}

--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/AppController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/AppController.java
@@ -55,6 +55,9 @@ public class AppController extends BaseController {
 		map.put("appTitle", getAppTitle(request));
 		map.put("container", buildContainerPath(mapping, request));
 		
+		ProxySpec[] apps = proxyService.getProxySpecs(null, false).toArray(new ProxySpec[0]);
+		map.put("apps", apps);
+
 		return "app";
 	}
 	

--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/IndexController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/IndexController.java
@@ -21,7 +21,9 @@
 package eu.openanalytics.shinyproxy.controllers;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -40,6 +42,12 @@ public class IndexController extends BaseController {
 		
 		ProxySpec[] apps = proxyService.getProxySpecs(null, false).toArray(new ProxySpec[0]);
 		map.put("apps", apps);
+		
+		Set<String> displayGroups = new HashSet<>();
+		for (ProxySpec app: apps) {
+			displayGroups.add(app.getDisplayGroup());
+		}
+		map.put("displayGroups", displayGroups.toArray(new String[0]));
 
 		Map<ProxySpec, String> appLogos = new HashMap<>();
 		map.put("appLogos", appLogos);

--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/IndexController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/IndexController.java
@@ -21,7 +21,7 @@
 package eu.openanalytics.shinyproxy.controllers;
 
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,7 +43,7 @@ public class IndexController extends BaseController {
 		ProxySpec[] apps = proxyService.getProxySpecs(null, false).toArray(new ProxySpec[0]);
 		map.put("apps", apps);
 		
-		Set<String> displayGroups = new HashSet<>();
+		Set<String> displayGroups = new LinkedHashSet<>();
 		for (ProxySpec app: apps) {
 			displayGroups.add(app.getDisplayGroup());
 		}


### PR DESCRIPTION
Hi,

This PR will enable users to define a field `proxy.spec.displayGroup` in the application.yml, which allows the apps being grouped in the shinyproxy webpages. For example, users can build several navbar menus, each of which displays the app links of the same groups.

Moreover, since the navbar menu is displayed in places including index, admin and app. This PR provides both `apps` and `displayGroups` to those entrypoints above.

Related to 
https://github.com/openanalytics/containerproxy/pull/16