### PR TITLE
Fix page objects offset with Chrome 73

### DIFF
--- a/src/main/resources/static/css/default.css
+++ b/src/main/resources/static/css/default.css
@@ -22,7 +22,7 @@ body > div { padding-top: 10px; }
 body > div#navbar { padding-top: 0px; }
 
 #navbar + div { padding-top: 50px; }
-#navbar + iframe { padding-top: 50px; }
+#navbar + iframe { margin-top: 50px; }
 
 @media screen and (max-width: 768px) {
    #navbar + div { padding-top: 150px; }


### PR DESCRIPTION
This seems to fix the issue #139 regarding the offset. We noticed this when Shinydashboard with collapsible entries is used with Chrome 73. This triggers a displacement of the objects.

Changing the css from `padding-top` to `margin-top` seems to fix this.