### PR TITLE
Add health endpoint for monitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/eu/openanalytics/shinyproxy/UISecurityConfig.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/UISecurityConfig.java
@@ -62,6 +62,9 @@ public class UISecurityConfig implements ICustomSecurityConfig {
 
 			// Limit access to the admin pages
 			http.authorizeRequests().antMatchers("/admin").hasAnyRole(userService.getAdminGroups());
+
+			// Allow public access to health endpoint
+			http.authorizeRequests().antMatchers("/actuator/health").permitAll();
 		}
 	}
 }


### PR DESCRIPTION
As you may know, Kubernetes kubelet requires a Liveness probe to be able to determine if a container needs to be restarted or not (https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/). 

Using the `/login` would be an option but in the case of, for example, GKE load balancer health checks (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#health_checks) only  HTTP 200 responses are supported. In the case of basic authentication, this is not an issue but when you enable  OpenID authentication,  you will be redirected with an HTTP 302 response to the custom login page of the identity provider.

This pull request adds the actuator package which exposes operational information about the running Spring application. It also makes the health endpoint of the package publicly accessible.

Body when the application is up:

```
{
    "status": "UP"
}
```