### PR TITLE
add viewport meta tags to admin, app, index default pages

### DIFF
--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -26,6 +26,7 @@
 <head lang="en">
 	<title th:text="${title}"></title>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<link rel="stylesheet" media="screen" th:href="@{${resourcePrefix} + ${bootstrapCss}}"/>
 	<link rel="stylesheet" media="screen" th:href="@{${resourcePrefix} + '/css/default.css'}"/>
 	<link rel="stylesheet" media="screen" th:href="@{${resourcePrefix} + '/webjars/datatables/1.12.1/css/dataTables.bootstrap.min.css'}"/>

--- a/src/main/resources/templates/app.html
+++ b/src/main/resources/templates/app.html
@@ -26,6 +26,7 @@
 <head lang="en">
 	<title th:text="${appTitle} + ' - ' + ${appInstanceDisplayName}"></title>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<link rel="stylesheet" media="screen" th:href="@{${resourcePrefix} + ${bootstrapCss}}"/>
 	<link rel="stylesheet" media="screen" th:href="@{${resourcePrefix} + '/css/default.css'}"/>
 	<script th:src="@{${resourcePrefix} + ${jqueryJs}}"></script>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -26,6 +26,7 @@
 <head lang="en">
     <title th:text="${title}"></title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" media="screen" th:href="@{${resourcePrefix} + ${bootstrapCss}}"/>
     <link rel="stylesheet" media="screen" th:href="@{${resourcePrefix} + '/css/default.css'}"/>
     <script th:src="@{${resourcePrefix} + ${jqueryJs}}"></script>


### PR DESCRIPTION
Hi! As a user, I would expect that the default pages for index and app to try and scale for mobile browsers and it doesn't seem to at the moment because it is missing a meta tag as described [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#viewport_basics).

This PR adds the meta tag in question to the default templates for index.html, app.html, and admin.html so that the default behaviour is to support mobile. 

This is similar to an older/stale PR #179 