### PR TITLE
new feature: Add proxy.notification-message in settings

### DIFF
--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/BaseController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/BaseController.java
@@ -105,6 +105,7 @@ public abstract class BaseController {
 	protected void prepareMap(ModelMap map, HttpServletRequest request) {
         map.put("application_name", environment.getProperty("spring.application.name")); // name of ShinyProxy, ContainerProxy etc
 		map.put("title", environment.getProperty("proxy.title", "ShinyProxy"));
+        map.put("notificationMessage", environment.getProperty("proxy.notification-message"));
 		map.put("logo", resolveImageURI(environment.getProperty("proxy.logo-url")));
 
 		String hideNavBarParam = request.getParameter("sp_hide_navbar");

--- a/src/main/resources/static/css/default.css
+++ b/src/main/resources/static/css/default.css
@@ -261,3 +261,28 @@
 	width: 70px;
 	line-height: inherit;
 }
+
+/* CSS stylesheet for the notification banner */
+.notification-banner {
+    background-color: #ffc107; /* Yellow background color */
+    color: #333; /* Text color */
+    padding: 10px; /* Padding around the notification content */
+    font-size: 16px; /* Font size */
+    text-align: center; /* Center-align the text */
+    position: fixed; /* Fix the banner position */
+    top: 0; /* Position at the top of the page */
+    left: 0; /* Position on the left */
+    width: 100%; /* Set the width to fill the entire page */
+    z-index: 9999; /* Set a high z-index to ensure the banner is on top */
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1); /* Add a subtle shadow */
+}
+
+  /* CSS styles for the close button (X) */
+.notification-banner .close-button {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    font-size: 20px;
+    font-weight: bold;
+    cursor: pointer;
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -43,6 +43,12 @@
 <!-- navigation bar -->
 <div th:replace="fragments/navbar :: navbar"></div>
 
+<!-- Add the following code to show the notification banner -->
+<div th:if="${notificationMessage != null}" class="notification-banner">
+    <span class="close-button" onclick="this.parentElement.style.display='none'">&times;</span>
+    <p th:text="${notificationMessage}"> </p>
+</div>
+
 <!-- This is a fragment used to display a single app. -->
 <!-- Modify this in order to change how a single app looks. -->
 <th:block th:fragment="app(app)">


### PR DESCRIPTION
Hello,

Here is the use scenario. I need to do maintenance on the deployed shinyproxy.  There are many end users in the system, some are very active and some are not. While I want to notify them of the system outage but I don't want those inactive users to get spammed by email. 

Functions:
Add proxy.notification-message to the application.yml settings and if this setting exists, the home page will show a notification banner. Otherwise, nothing is shown.

Please take a look if this can be added to the future release.

Regards,

Robin