### PR TITLE
Try to fix gzip content

### DIFF
--- a/src/main/java/eu/openanalytics/shinyproxy/ShinyProxyIframeScriptInjector.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/ShinyProxyIframeScriptInjector.java
@@ -118,6 +118,7 @@ public class ShinyProxyIframeScriptInjector extends AbstractStreamSinkConduit<St
         // 1. check whether it's a html response and success
         if (exchange.getStatusCode() == HttpStatus.OK.value()
             && exchange.getResponseHeaders().get("Content-Type") != null
+            && exchange.getResponseHeaders().get("Content-Encoding") == null
             && exchange.getResponseHeaders().get("Content-Type").stream().anyMatch(headerValue -> headerValue.contains("text/html"))) {
             // 2. inject script
             String r = outputStream.toString(StandardCharsets.UTF_8);

--- a/src/main/java/eu/openanalytics/shinyproxy/controllers/AppController.java
+++ b/src/main/java/eu/openanalytics/shinyproxy/controllers/AppController.java
@@ -362,7 +362,6 @@ public class AppController extends BaseController {
         try {
             String scriptPath = contextPathHelper.withEndingSlash() + identifierService.instanceId + "/js/shiny.iframe.js";
             mappingManager.dispatchAsync(proxy, subPath, request, response, (exchange) -> {
-                exchange.getRequestHeaders().remove("Accept-Encoding"); // ensure no encoding is used
                 exchange.addResponseWrapper((factory, exchange1) -> new ShinyProxyIframeScriptInjector(factory.create(), exchange1, scriptPath));
             });
         } catch (Exception e) {


### PR DESCRIPTION
Hello,
After updating from shinyproxy version 2.6.1 to 3.1.0 some pages were no longer displayed properly.
What I noticed was that the Content-Encoding was no longer present in the response.

With 3.1.0:
![image](https://github.com/openanalytics/shinyproxy/assets/1595998/2bfa6d87-39e0-4725-be38-667c38df5c21)

With 2.6.1:
![image](https://github.com/openanalytics/shinyproxy/assets/1595998/87692bfc-09cf-4acd-b296-35721fa0e28e)

I am attaching a possible PR which resolves my problem and I have not noticed any regression in my applications but I was able to omit tests. I'll let you see if my PR is acceptable or not and if not I'm open to any other solution that would allow me to use the latest version.

Thank you

Regards,